### PR TITLE
Add Kaleidoscope to the list of firmwares

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 ## Firmware
 - [QMK](https://github.com/qmk/qmk_firmware)
 - [TMK](https://github.com/tmk/tmk_keyboard)
+- [Kaleidoscope](https://github.com/keyboardio/Kaleidoscope)
 
 ## Tutorials
 - [A modern handwiring guide](https://geekhack.org/index.php?topic=87689.0)


### PR DESCRIPTION
Kaleidoscope is the official firmware of the Keyboardio Model01, Dygma Raise, and Keyboardio's upcoming keyboard. It also supports the ErgoDox (and anything that is wired like an original ErgoDox, like the EZ and many Dactyls), the Atreus, and support is coming for more (Planck among them).

While not as wide spread as TMK and QMK, it has a considerably different architecture, making it an interesting open source firmware.