### PR TITLE
Added my own keyboard firmware to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 - [Keyplus](https://github.com/ahtn/keyplus)
 - [QMK](https://github.com/qmk/qmk_firmware)
 - [TMK](https://github.com/tmk/tmk_keyboard)
+- [Mechy](https://github.com/colinta/Mechy) - Arduino compatible, plugin based.
 
 
 ## Tutorials


### PR DESCRIPTION
Mechy is great, I think more people should use it! Shameless self promotion.

But also Mechy really is a great firmware alternative to the others listed here.  It's the only, afaik, Arduino based solution, which has a great appeal for anyone that is plugging a pro micro into one of keeb.io's boards.  You don't need to mess with reprogramming the microcontroller to use dfu or whatever, just download Mechy and get going.