### PR TITLE
Add descriptions to the firmwares where it was missing

### DIFF
--- a/docs/firmware.md
+++ b/docs/firmware.md
@@ -2,9 +2,9 @@
 
 - [BlueMicro_BLE](https://github.com/jpconstantineau/BlueMicro_BLE) - A Bluetooth Firmware for the NRF52832.
 - [Bluetosis](https://github.com/geoah/bluetosis) - Bluetooth firmware for the Mitosis keyboard.
-- [Kaleidoscope](https://github.com/keyboardio/Kaleidoscope)
-- [Keyplus](https://github.com/ahtn/keyplus)
+- [Kaleidoscope](https://github.com/keyboardio/Kaleidoscope) - Flexible firmware for Arduino-powered keyboards.
+- [Keyplus](https://github.com/ahtn/keyplus) - An easy to use keyboard firmware with support for wireless and wired split keyboards.
 - [Mechy](https://github.com/colinta/Mechy) - Arduino compatible, plugin based.
 - [MK32](https://github.com/Galzai/MK32) - Simple BLE keyboard for ESP32
-- [QMK](https://github.com/qmk/qmk_firmware)
-- [TMK](https://github.com/tmk/tmk_keyboard)
+- [QMK](https://github.com/qmk/qmk_firmware) - A keyboard firmware based on the tmk_keyboard firmware for Atmel AVR and ARM controllers.
+- [TMK](https://github.com/tmk/tmk_keyboard) - Keyboard firmwares for Atmel AVR and Cortex-M.


### PR DESCRIPTION
Some of the firmwares were missing a description, this PR adds them based on what their descriptions in their respective Readme are.