### PR TITLE
docs: add kb-fx to Tools

### DIFF
--- a/src/pages/en/tools.md
+++ b/src/pages/en/tools.md
@@ -11,6 +11,7 @@ layout: ../../layouts/MarkdownLayout.astro
 - [Capistry](https://github.com/larssont/capistry) - A Python package for parametric 3D modeling of keyboard keycaps using build123d.
 - [Kalerator](https://kalerator.clueboard.co) - Pcb generator for keyboard-layout-editor generated layouts. [GitHub Site](https://github.com/skullydazed/kalerator), [Eagle Parts Library](https://github.com/skullydazed/clueboard_eagle)
 - [Karabiner-Elements](https://github.com/tekezo/Karabiner-Elements) - Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.
+- [kb-fx](https://github.com/MrBogomips/kb-fx) - macOS CLI that plays a synthesized sound on every keystroke on any keyboard, and sets backlight colors on VIA-compatible boards over raw HID.
 - [kbpcb](http://kbpcb.mrkeebs.com/) - Create KiCad PCB files from [KLE](http://www.keyboard-layout-editor.com) json files [Github page](https://github.com/fcoury/kbpcb)
 - [keyboard-layout-editor](http://www.keyboard-layout-editor.com/) - Is a web application that enables the editing of keyboard-layouts, i.e., the position and appearance of each physical key. [GitHub Site](https://github.com/ijprest/keyboard-layout-editor)
 - [Keyboard Layout 3D Viewer](https://github.com/eswai/KL3V) - 3D render keyboard-layout-editor.com layouts


### PR DESCRIPTION
Adds **kb-fx** to the Tools page.

`- [kb-fx](https://github.com/MrBogomips/kb-fx) - macOS CLI that plays a synthesized sound on every keystroke on any keyboard, and sets backlight colors on VIA-compatible boards over raw HID.`

### What it is

A macOS command-line tool with two halves:

- **Sound** — a synthesized tone per keystroke, captured with a listen-only
  Quartz event tap, so it works with *any* keyboard, not just QMK/VIA boards.
  Several modes, including melodies (bundled, or imported from MIDI) that
  advance one note per key.
- **Lights** — VIA protocol v2 over raw HID to set backlight colors while you
  type. Boards are auto-detected; known-good on a Keychron K8 Pro, and it
  degrades to sound-only when no lights-capable board is present.
  It never sends `lighting_save` (0x09), so it does not write keyboard EEPROM.

MIT licensed, `brew install mrbogomips/tap/kb-fx`, `kb-fx doctor` for
permission/device diagnostics.

Placed alphabetically between `Karabiner-Elements` and `kbpcb`.
